### PR TITLE
Refactor NullAgent and NeutralAgent to use HoldBehaviourMixin

### DIFF
--- a/ai_diplomacy/agents/factory.py
+++ b/ai_diplomacy/agents/factory.py
@@ -85,6 +85,8 @@ class AgentFactory:
             return self._create_scripted_agent(agent_id, country, config)
         elif config.type == "neutral":  # New condition for NeutralAgent
             return self._create_neutral_agent(agent_id, country, config)
+        elif config.type == "null": # "null" type will use NeutralAgent's creation logic
+            return self._create_neutral_agent(agent_id, country, config)
         elif config.type == "bloc_llm":  # New condition for BlocLLMAgent
             if not bloc_name or not controlled_powers:
                 raise ValueError(
@@ -268,6 +270,7 @@ class AgentFactory:
                 "scripted",
                 "neutral",
                 "bloc_llm",
+                "null", # Added "null" as a valid type
             ]:  # Added new types
                 logger.error(f"Invalid agent type: {config.type}")
                 return False

--- a/ai_diplomacy/agents/neutral_agent.py
+++ b/ai_diplomacy/agents/neutral_agent.py
@@ -1,9 +1,9 @@
 from typing import List, Dict, Any
-from .base import BaseAgent, Order, Message
+from .base import BaseAgent, Order, Message, HoldBehaviourMixin
 from ..core.state import PhaseState
 
 
-class NeutralAgent(BaseAgent):
+class NeutralAgent(BaseAgent, HoldBehaviourMixin):
     """
     An agent that represents a neutral power.
     It always issues HOLD orders for all its units and does not engage in negotiation.
@@ -16,21 +16,9 @@ class NeutralAgent(BaseAgent):
     async def decide_orders(self, phase: PhaseState) -> List[Order]:
         """
         Decide what orders to submit for the current phase.
-        Neutral agents always HOLD all their units.
+        Neutral agents always HOLD all their units using HoldBehaviourMixin.
         """
-        orders = []
-        power_state = phase.get_power_state(self.country)
-        if power_state:
-            for unit in power_state.units:
-                # Assuming unit is a string like "A PAR", "F MAR", etc.
-                # Or if unit is an object, it should have a 'location' or 'name' attribute.
-                # For simplicity, let's assume unit string includes its location.
-                # A HOLD order is just the unit itself.
-                # Example: "A PAR H" or "F MAR H"
-                # The diplomacy library expects orders like: "A PAR HLD"
-                # Unit name is like "A PAR", "F MAR"
-                orders.append(Order(f"{unit} HLD"))
-        return orders
+        return self.get_hold_orders(phase)
 
     async def negotiate(self, phase: PhaseState) -> List[Message]:
         """

--- a/ai_diplomacy/agents/null_agent.py
+++ b/ai_diplomacy/agents/null_agent.py
@@ -1,10 +1,9 @@
 from typing import List, Dict, Any, Optional
 
-from .base import BaseAgent, Order, Message
-from diplomacy import Game
+from .base import BaseAgent, Order, Message, HoldBehaviourMixin
 from ..core.state import PhaseState
 
-class NullAgent(BaseAgent):
+class NullAgent(BaseAgent, HoldBehaviourMixin):
     """
     An agent that represents an uncontrolled power or a power in civil disorder.
     It always issues hold orders and does not participate in negotiations.
@@ -17,26 +16,8 @@ class NullAgent(BaseAgent):
         # NullAgent does not use an LLM, so model_id and related attributes are not needed.
 
     async def decide_orders(self, phase: PhaseState) -> List[Order]:
-        """Generates hold orders for all units of the controlled power."""
-        orders = []
-        # self.country is the power_name for this agent, set in BaseAgent's __init__
-        power_name_upper = self.country.upper()
-
-        # Access units from PhaseState if available, otherwise need to adjust
-        # Assuming PhaseState has a way to get units for a power.
-        # For now, let's assume phase.get_units(power_name) exists or adapt based on PhaseState structure.
-        # From the traceback, NullAgent was instantiated, so game.powers was likely available before.
-        # Let's use a simplified approach for now assuming PhaseState provides units.
-        # If PhaseState doesn't directly provide units like diplomacy.Game, this will need adjustment
-        # based on PhaseState's actual API.
-        # For now, we'll try to access units via phase.game.get_units if phase.game is the diplomacy.Game instance.
-        
-        current_game_state = phase.game # Assuming phase.game is the diplomacy.Game object
-
-        if power_name_upper in current_game_state.powers:
-            for unit in current_game_state.get_units(power_name_upper):
-                orders.append(Order(f"{unit} H")) # Wrap in Order object
-        return orders
+        """Generates hold orders for all units of the controlled power using HoldBehaviourMixin."""
+        return self.get_hold_orders(phase)
 
     async def negotiate(self, phase: PhaseState) -> List[Message]:
         """NullAgent does not send messages."""
@@ -48,38 +29,6 @@ class NullAgent(BaseAgent):
         """NullAgent does not maintain complex internal state from game events."""
         pass # No state to update
 
-    # Keeping existing helper methods if they were used by other parts,
-    # but the abstract methods above are the primary interface.
-    # The original generate_orders, generate_messages, etc., can be removed or kept as internal helpers
-    # if decide_orders and negotiate call them. For NullAgent, the logic is simple enough to be direct.
-
-    async def generate_orders(self, game: Game, power_name: str) -> List[str]:
-        """Generates hold orders for all units of the controlled power. (Old method, can be removed)"""
-        # This can be removed if decide_orders is self-contained
-        orders_str = []
-        if power_name.upper() in game.powers:
-            for unit in game.get_units(power_name.upper()):
-                orders_str.append(f"{unit} H")
-        return orders_str
-
-    async def generate_messages(
-        self, game: Game, power_name: str, current_year: int, current_phase: str
-    ) -> List[Message]:
-        """NullAgent does not send messages. (Old method, can be removed)"""
-        return []
-
-    async def respond_to_messages(
-        self, game: Game, power_name: str, received_messages: List[Message]
-    ) -> List[Message]:
-        """NullAgent does not respond to messages. (Old method, can be removed)"""
-        return []
-    
-    async def plan_next_phase(
-        self, game: Game, power_name: str, current_year: int, current_phase: str
-    ) -> str:
-        """NullAgent does not plan. (Old method, can be removed)"""
-        return "No plan as this is a NullAgent."
-
     def get_model_id(self) -> Optional[str]:
         """NullAgent does not have a model ID."""
-        return None 
+        return None

--- a/tests/unit/test_null_agent_hold.py
+++ b/tests/unit/test_null_agent_hold.py
@@ -1,0 +1,151 @@
+import pytest
+from unittest.mock import Mock, MagicMock
+
+from ai_diplomacy.agents.neutral_agent import NeutralAgent
+from ai_diplomacy.agents.base import Order
+from ai_diplomacy.core.state import PhaseState
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def mock_phase_state() -> MagicMock:
+    """Creates a mock PhaseState object with a nested game mock."""
+    phase_state = MagicMock(spec=PhaseState)
+    phase_state.game = MagicMock()  # Mock the 'game' attribute
+    return phase_state
+
+async def test_neutral_agent_hold_orders_from_power_state(mock_phase_state: MagicMock):
+    """
+    Tests that NeutralAgent generates hold orders correctly using phase.get_power_state().units.
+    """
+    agent = NeutralAgent(agent_id="test_neutral_france", country="FRANCE")
+    
+    mock_power_state_france = MagicMock()
+    mock_power_state_france.units = ["A PAR", "F MAR"]
+    
+    mock_phase_state.get_power_state.return_value = mock_power_state_france
+    # Ensure fallback is not called or its return doesn't interfere
+    mock_phase_state.game.get_units.return_value = [] 
+
+    orders = await agent.decide_orders(mock_phase_state)
+
+    mock_phase_state.get_power_state.assert_called_once_with("FRANCE")
+    # We don't want to assert not_called for game.get_units because the mixin might try the first path,
+    # fail due to structure (if units not directly there), then try the second.
+    # The important part is that mock_power_state_france.units was the source.
+    # If the first path in HoldBehaviourMixin's try block for power_state.units is successful,
+    # phase.game.get_units should not be *relied upon*.
+
+    assert len(orders) == 2
+    assert Order("A PAR HLD") in orders
+    assert Order("F MAR HLD") in orders
+    # Check exact order objects if necessary, or just their string representations
+    expected_orders = [Order("A PAR HLD"), Order("F MAR HLD")]
+    assert all(o in orders for o in expected_orders) and len(orders) == len(expected_orders)
+
+async def test_neutral_agent_hold_orders_fallback_to_game_get_units(mock_phase_state: MagicMock):
+    """
+    Tests that NeutralAgent generates hold orders correctly using phase.game.get_units()
+    when phase.get_power_state().units is not available or get_power_state returns None.
+    """
+    agent = NeutralAgent(agent_id="test_neutral_italy", country="ITALY")
+
+    # Scenario 1: get_power_state returns None
+    mock_phase_state.get_power_state.return_value = None
+    mock_phase_state.game.get_units.return_value = ["A ROM", "F NAP"]
+
+    orders = await agent.decide_orders(mock_phase_state)
+
+    mock_phase_state.get_power_state.assert_called_once_with("ITALY")
+    mock_phase_state.game.get_units.assert_called_once_with("ITALY")
+    
+    assert len(orders) == 2
+    assert Order("A ROM HLD") in orders
+    assert Order("F NAP HLD") in orders
+    expected_orders = [Order("A ROM HLD"), Order("F NAP HLD")]
+    assert all(o in orders for o in expected_orders) and len(orders) == len(expected_orders)
+
+    # Reset mocks for Scenario 2
+    mock_phase_state.reset_mock()
+    mock_phase_state.game.reset_mock() # Also reset the game mock
+
+    # Scenario 2: get_power_state().units raises AttributeError (or object has no 'units')
+    mock_power_state_no_units = MagicMock()
+    del mock_power_state_no_units.units # Ensure it doesn't have 'units'
+    
+    # Alternative for stricter AttributeError simulation if needed:
+    # mock_power_state_no_units = MagicMock(spec=['some_other_attribute']) 
+    # or
+    # type(mock_power_state_no_units).units = PropertyMock(side_effect=AttributeError)
+
+
+    mock_phase_state.get_power_state.return_value = mock_power_state_no_units
+    mock_phase_state.game.get_units.return_value = ["A VEN", "F TRI"]
+
+    orders_scenario2 = await agent.decide_orders(mock_phase_state)
+
+    mock_phase_state.get_power_state.assert_called_with("ITALY") # Called again
+    mock_phase_state.game.get_units.assert_called_with("ITALY") # Called again
+    
+    assert len(orders_scenario2) == 2
+    assert Order("A VEN HLD") in orders_scenario2
+    assert Order("F TRI HLD") in orders_scenario2
+    expected_orders_s2 = [Order("A VEN HLD"), Order("F TRI HLD")]
+    assert all(o in orders_scenario2 for o in expected_orders_s2) and len(orders_scenario2) == len(expected_orders_s2)
+
+
+async def test_neutral_agent_no_units(mock_phase_state: MagicMock):
+    """
+    Tests that NeutralAgent returns an empty list of orders when the power has no units.
+    """
+    agent = NeutralAgent(agent_id="test_neutral_germany", country="GERMANY")
+
+    # Scenario 1: Power state has no units
+    mock_power_state_no_units = MagicMock()
+    mock_power_state_no_units.units = []
+    mock_phase_state.get_power_state.return_value = mock_power_state_no_units
+    mock_phase_state.game.get_units.return_value = [] # Fallback also returns no units
+
+    orders = await agent.decide_orders(mock_phase_state)
+    assert orders == []
+
+    # Reset and test Scenario 2: get_power_state returns None, and game.get_units returns []
+    mock_phase_state.reset_mock()
+    mock_phase_state.game.reset_mock()
+    
+    mock_phase_state.get_power_state.return_value = None
+    mock_phase_state.game.get_units.return_value = []
+
+    orders_scenario2 = await agent.decide_orders(mock_phase_state)
+    assert orders_scenario2 == []
+    mock_phase_state.get_power_state.assert_called_once_with("GERMANY")
+    mock_phase_state.game.get_units.assert_called_once_with("GERMANY")
+
+async def test_neutral_agent_unit_object_to_string(mock_phase_state: MagicMock):
+    """
+    Tests that NeutralAgent correctly converts unit objects (if any) to strings.
+    The HoldBehaviourMixin uses str(unit_name).
+    """
+    agent = NeutralAgent(agent_id="test_neutral_austria", country="AUSTRIA")
+    
+    # Mock unit objects that have a __str__ method
+    class MockUnit:
+        def __init__(self, name):
+            self.name = name
+        def __str__(self):
+            return self.name
+
+    mock_power_state_austria = MagicMock()
+    mock_power_state_austria.units = [MockUnit("A VIE"), MockUnit("F BUD")] # Units are objects
+    
+    mock_phase_state.get_power_state.return_value = mock_power_state_austria
+    mock_phase_state.game.get_units.return_value = [] # Fallback not used
+
+    orders = await agent.decide_orders(mock_phase_state)
+
+    assert len(orders) == 2
+    assert Order("A VIE HLD") in orders
+    assert Order("F BUD HLD") in orders
+    expected_orders = [Order("A VIE HLD"), Order("F BUD HLD")]
+    assert all(o in orders for o in expected_orders) and len(orders) == len(expected_orders)


### PR DESCRIPTION
- I created `HoldBehaviourMixin` to centralize "HOLD" order logic.
- I refactored `NullAgent` and `NeutralAgent` to inherit from this mixin, simplifying their `decide_orders` methods.
- I removed legacy `generate_*` methods from `NullAgent`.
- I updated `AgentFactory` to map "null" agent type to `NeutralAgent`, effectively using `NeutralAgent` for both "null" and "neutral" configurations.
- I added "null" as a valid type in `AgentFactory`'s validation.
- I added unit tests for `NeutralAgent` (covering "null" type behavior) to verify correct "HLD" order generation, including fallback logic for unit retrieval.

This change unifies the behavior of passive agents, reduces code duplication, and meets the specified LOC and method naming requirements. NullAgent LOC: ~31
NeutralAgent LOC: ~32
Total LOC: ~63 (Requirement: <=120)