### PR TITLE
feat: Add dead-code detection and coverage gate to CI

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -39,12 +39,12 @@ jobs:
         else
           echo "No 'legacy interface' markers found. Check passed."
         fi
-    
-    #- name: Lint with Ruff
-     # uses: astral-sh/ruff-action@v3
-     # with:
-     #   args: "check --diff . && ruff format --check --diff ."
+
+    - name: Lint with Ruff
+      uses: astral-sh/ruff-action@v3 # Or the latest version of ruff-action
+      with:
+        args: "check . && ruff format --check ."
 
     - name: Run unit tests with pytest
       run: |
-        uv run pytest -q
+        uv run coverage run -m pytest && uv run coverage xml && uv run coverage report --fail-under=50

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ branch = true
 omit   = ["*/__init__.py", "*/migrations/*", "*/tests/*"]
 
 [tool.coverage.report]
-fail_under = 40          # start at 80 %, ratchet upward later
+fail_under = 50
 show_missing = true
 
+[tool.ruff]
+lint.select = ["F","B","E","I","UP","PL","D","PYI","RUF"]
+lint.ignore = ["D100","D104"]

--- a/run_wwi_test.py
+++ b/run_wwi_test.py
@@ -1,3 +1,4 @@
+# pragma: no cover
 import argparse
 import asyncio
 import logging

--- a/tests/integration/test_lm_game_orchestrator.py
+++ b/tests/integration/test_lm_game_orchestrator.py
@@ -1,0 +1,38 @@
+import subprocess
+import pytest
+from pathlib import Path
+
+# Define the root directory of the project
+ROOT_DIR = Path(__file__).resolve().parents[2]
+
+@pytest.mark.integration
+def test_lm_game_wwi_two_player_spring_1901():
+    """
+    Runs lm_game.py --scenario wwi_two_player for one Spring season (Spring 1901)
+    to exercise orchestrator paths.
+    """
+    scenario_file = ROOT_DIR / "wwi_scenario.toml"
+    command = [
+        "python",
+        str(ROOT_DIR / "lm_game.py"),
+        "--scenario",
+        "wwi_two_player",
+        "--scenario-file",
+        str(scenario_file),
+        "--phase-limit",
+        "Spring 1901"
+    ]
+
+    # It's good practice to capture stdout and stderr, and check the return code.
+    process = subprocess.run(command, capture_output=True, text=True, cwd=ROOT_DIR)
+
+    # Assert that the command executed successfully
+    assert process.returncode == 0, f"lm_game.py execution failed with error: {process.stderr}"
+
+    # Add more specific assertions based on expected output or side effects if necessary.
+    # For now, a successful run (returncode 0) is the primary check.
+    # Check if critical orchestrator components were logged or if specific output exists.
+    # Example (needs adjustment based on actual game output):
+    # assert "Orchestrating Spring 1901 Movement Phase" in process.stdout
+    # assert "Orchestrating Spring 1901 Retreat Phase" in process.stdout # If applicable
+    # assert "Orchestrating Spring 1901 Build Phase" in process.stdout # If applicable


### PR DESCRIPTION
This commit introduces several improvements to the CI pipeline and code quality checks:

1.  **Enable Ruff's Dead-Code Plugin**:
    *   Added `RUF` to `tool.ruff.lint.select` in `pyproject.toml` to enable Ruff's dead-code detection capabilities.
    *   Uncommented and updated the Ruff linting step in the GitHub Actions workflow (`.github/workflows/python-test.yml`) to run `ruff check .` and `ruff format --check .`.

2.  **Implement Coverage Gate**:
    *   Modified the pytest execution command in the GitHub Actions workflow to `uv run coverage run -m pytest && uv run coverage xml && uv run coverage report --fail-under=50`. This ensures that tests are run with coverage, an XML report is generated, and the CI job fails if test coverage drops below 50%.
    *   Updated `tool.coverage.report.fail_under` in `pyproject.toml` from 40 to 50 to align with the CI gate.

3.  **Add Integration Test for Orchestrator Paths**:
    *   Created a new integration test (`tests/integration/test_lm_game_orchestrator.py`) that runs `lm_game.py --scenario wwi_two_player --phase-limit "Spring 1901"` to exercise core orchestrator paths.

4.  **Mark Legacy Script for No Coverage**:
    *   Added `# pragma: no cover` to `run_wwi_test.py`, as it's a utility/test-runner script and not part of the core library requiring full coverage.

These changes will help prevent regressions by automatically detecting unused code and ensuring that test coverage for core modules does not drop, leading to better code quality and maintainability for you.