### PR TITLE
Fix imports and cleanup tests

### DIFF
--- a/ai_diplomacy/agents/__init__.py
+++ b/ai_diplomacy/agents/__init__.py
@@ -6,8 +6,8 @@ LLM-based agents and scripted agents, as well as factories for creating agents.
 """
 
 from .base import BaseAgent
-from ..core.order import Order
-from ..core.message import Message
+from ..domain.order import Order
+from ..domain.message import Message
 from .llm_agent import LLMAgent
 from .scripted_agent import ScriptedAgent
 from .neutral_agent import NeutralAgent

--- a/ai_diplomacy/agents/history_interpreter.py
+++ b/ai_diplomacy/agents/history_interpreter.py
@@ -2,7 +2,7 @@
 Functions to interpret and format game history for consumption by AI agents.
 """
 
-from __future__ in annotations
+from __future__ import annotations
 
 import logging
 from collections import defaultdict
@@ -14,9 +14,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def get_messages_this_round(
-    history: GameHistory, power_name: str, current_phase_name: str
-) -> str:
+def get_messages_this_round(history: GameHistory, power_name: str, current_phase_name: str) -> str:
     current_phase: Optional[Phase] = None
     for phase_obj in history.phases:
         if phase_obj.name == current_phase_name:
@@ -55,9 +53,7 @@ def get_messages_this_round(
             messages_str += conversation_content
             messages_str += "\n"
     else:
-        messages_str += (
-            "\n**PRIVATE MESSAGES TO/FROM YOU THIS ROUND:**\n (No private messages this round)\n"
-        )
+        messages_str += "\n**PRIVATE MESSAGES TO/FROM YOU THIS ROUND:**\n (No private messages this round)\n"
 
     if not global_msgs_content and not conversations:
         return f"\n(No messages recorded for current phase: {current_phase_name})\n"
@@ -65,7 +61,9 @@ def get_messages_this_round(
     return messages_str.strip()
 
 
-def get_recent_messages_to_power(history: GameHistory, power_name: str, limit: int = 3) -> List[Dict[str, str]]:
+def get_recent_messages_to_power(
+    history: GameHistory, power_name: str, limit: int = 3
+) -> List[Dict[str, str]]:
     """
     Gets the most recent messages sent TO this power, useful for tracking messages that need replies.
     Returns a list of dictionaries with 'sender', 'content', and 'phase' keys.
@@ -152,10 +150,7 @@ def get_ignored_messages_by_power(
                     else:
                         if m["sender"] == recipient and (
                             m["recipient"] == sender_name
-                            or (
-                                m["recipient"] in ["GLOBAL", "ALL"]
-                                and sender_name in m.get("content", "")
-                            )
+                            or (m["recipient"] in ["GLOBAL", "ALL"] and sender_name in m.get("content", ""))
                         ):
                             response_msgs.append(m)
 
@@ -267,4 +262,4 @@ def get_previous_phases_history(
     ).strip():
         return "\n(No relevant previous game history to display)\n"
 
-    return game_history_str.strip() 
+    return game_history_str.strip()

--- a/ai_diplomacy/agents/mixins/hold_behaviour_mixin.py
+++ b/ai_diplomacy/agents/mixins/hold_behaviour_mixin.py
@@ -5,8 +5,8 @@ Mixin class providing a simple hold order generation behaviour.
 from typing import List
 
 # Adjusted import path assuming core is one level up from agents directory
-from ...core.state import PhaseState
-from ...core.order import Order
+from ...domain.state import PhaseState
+from ...domain.order import Order
 
 __all__ = ["HoldBehaviourMixin"]
 

--- a/ai_diplomacy/agents/neutral_agent.py
+++ b/ai_diplomacy/agents/neutral_agent.py
@@ -1,9 +1,9 @@
 from typing import List, Dict, Any
 from .mixins.hold_behaviour_mixin import HoldBehaviourMixin
-from ..core.order import Order
-from ..core.message import Message  # Import Message
+from ..domain.order import Order
+from ..domain.message import Message
 from .base import BaseAgent
-from ..core.state import PhaseState
+from ..domain.state import PhaseState
 
 
 class NeutralAgent(BaseAgent, HoldBehaviourMixin):

--- a/ai_diplomacy/agents/null_agent.py
+++ b/ai_diplomacy/agents/null_agent.py
@@ -1,10 +1,10 @@
 from typing import List, Dict, Any, Optional
 
 from .base import BaseAgent
-from ..core.order import Order
-from ..core.message import Message
+from ..domain.order import Order
+from ..domain.message import Message
 from .mixins.hold_behaviour_mixin import HoldBehaviourMixin
-from ..core.state import PhaseState
+from ..domain.state import PhaseState
 
 
 class NullAgent(BaseAgent, HoldBehaviourMixin):

--- a/ai_diplomacy/agents/scripted_agent.py
+++ b/ai_diplomacy/agents/scripted_agent.py
@@ -7,8 +7,7 @@ import random
 from typing import List, Dict, Any, Optional
 from ai_diplomacy.domain import Order, PhaseState
 from .base import BaseAgent
-from ..core.message import Message  # Corrected
-from diplomacy import Game
+from ..domain.message import Message
 
 __all__ = ["ScriptedAgent"]
 

--- a/ai_diplomacy/domain/__init__.py
+++ b/ai_diplomacy/domain/__init__.py
@@ -1,8 +1,9 @@
 """Public interface for the domain layer."""
+
 from .adapter_diplomacy import game_to_phase
 from .board import BoardState
 from .game_history import PhaseHistory
-from .messaging import DiploMessage
+from .message import Message as DiploMessage
 from .order import Order
 from .phase import PhaseKey, PhaseState
 

--- a/ai_diplomacy/runtime/negotiation.py
+++ b/ai_diplomacy/runtime/negotiation.py
@@ -12,10 +12,9 @@ from .agents import get_agent_by_power
 if TYPE_CHECKING:
     from diplomacy import Game
     from ..game_history import GameHistory
-    from ..core.state import PhaseState  # For type checking current_phase_state
+    from ..domain.state import PhaseState  # For type checking current_phase_state
     from ..services.config import GameConfig  # For num_negotiation_rounds
     from ..agent_manager import AgentManager  # For get_agent
-    from ..agents.base import BaseAgent
 """
 Handles the negotiation process between agents during a Diplomacy game phase.
 

--- a/ai_diplomacy/runtime/phase_orchestrator.py
+++ b/ai_diplomacy/runtime/phase_orchestrator.py
@@ -115,7 +115,7 @@ class PhaseOrchestrator:  # Renamed from GamePhaseOrchestrator
 
         logger.info("PhaseOrchestrator initialized.")
 
-    async def run_game_loop(self, game: "GameState", game_history: "GameHistory"):
+    async def run_game_loop(self, game: "Game", game_history: "GameHistory"):
         logger.info(f"Starting game loop for game ID: {self.game_config.game_id}")
         self.game_config.game_instance = game
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import random
 from typing import Generator
 
-import numpy
 import pytest
 
 
@@ -58,9 +57,8 @@ def rule_agent():
 
 @pytest.fixture(scope="function")
 def seed_random() -> Generator[None, None, None]:
-    """random.seed(123) + numpy.random.seed(123); guards flakiness."""
+    """random.seed(123) guards flakiness."""
     random.seed(123)
-    numpy.random.seed(123)
     yield
     # No cleanup needed after
 

--- a/tests/unit/domain/test_order_norm.py
+++ b/tests/unit/domain/test_order_norm.py
@@ -1,16 +1,13 @@
 import pytest
-from hypothesis import given, strategies as st
 
-# This is a placeholder for a real domain object
-# from ai_diplomacy.domain import ...
-any_valid_order = st.text(min_size=1, alphabet="ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890-[]().")
+EXAMPLE_ORDERS = [
+    "A PAR H",
+    "F BRE-MAO",
+    "A MAR S F BRE-MAO",
+]
 
 @pytest.mark.unit
-@given(order=any_valid_order)
-def test_order_round_trip(order: str):
-    """
-    Property-based tests catch edge-cases in the move-parser earlier than integration games.
-    """
-    # norm = domain.utils.norm(order)
-    # assert domain.utils.denorm(norm) == order
-    assert isinstance(order, str) 
+@pytest.mark.parametrize("order", EXAMPLE_ORDERS)
+def test_order_round_trip(order: str) -> None:
+    """Simplistic regression test placeholder for order parsing."""
+    assert isinstance(order, str)


### PR DESCRIPTION
## Summary
- fix broken import paths using domain package
- correct __future__ statement in history_interpreter
- remove numpy dependency from tests
- simplify order normalization test
- fix type hints in runtime modules

## Testing
- `uv run --frozen ruff format .`
- `uv run --frozen ruff check --fix .`
- `uv run --frozen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856b72cdecc8331ba20bee1980d43ac